### PR TITLE
open new browser tabs for links to external urls

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,6 @@
 <div id="footer">
   <div class="container">
- 	  <p class="text-center">Join the discussion: <a href="http://groups.google.com/group/openlexington?lnk=srg" title="OpenLexington | Google Groups">openlexington</a> | Follow us on twitter: <a href="http://twitter.com/openlexington/" title="Follow OpenLexington on Twitter">@openlexington</a> | Fork our code on GitHub: <a href="http://github.com/openlexington" title="openlexington's Profile - GitHub">openlexington</a><br /><br />
+ 	  <p class="text-center">Join the discussion: <a href="http://groups.google.com/group/openlexington?lnk=srg" title="OpenLexington | Google Groups" target="_blank">openlexington</a> | Follow us on twitter: <a href="http://twitter.com/openlexington/" title="Follow OpenLexington on Twitter" target="_blank">@openlexington</a> | Fork our code on GitHub: <a href="http://github.com/openlexington" title="openlexington's Profile - GitHub" target="_blank">openlexington</a><br /><br />
 		OpenLexington is a non-partisan, non-profit organization. <br />
     &copy; OpenLexington 2015 This work is licensed under a creative-commons attribution, non-commercial license.<br />
 	  </p>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -16,7 +16,7 @@
           <li><a href="getinvolved.html" title="Get Involved ">Get Involved</a></li>
           <li><a href="codeofconduct.html" title="Code of Conduct">Code of Conduct</a></li>
           <li><a href="http://data.lexingtonky.gov" title="Open Data Catalog">Data</a></li>
-          <li><a href="http://github.com/openlexington" title="Fork our code at GitHub">Code</a></li>
+          <li><a href="http://github.com/openlexington" title="Fork our code at GitHub" target="_blank">Code</a></li>
       </ul>
     </div><!--/.nav-collapse -->
   </div>

--- a/about.html
+++ b/about.html
@@ -16,7 +16,7 @@ layout: default
   <hr>
 
   <h2>What is Open Data?</h2>
-  <p class="undo-indent">The following attributes were taken from the <a href="http://resource.org/8_principles.html" title="8 Principles of Open Government Data">8 principles</a> of open data developed in 2007 at the <a href="http://public.resource.org/open_government_meeting.html" title="Memorandum">Open Government Working Group</a> along with recent additional <a href="http://sunlightfoundation.com/policy/documents/ten-open-data-principles/" title="Policy Center - Ten Principles for Opening Up Government Information - SunlightFoundation.com">suggestions</a> by the <a href="http://sunlightfoundation.com/" title="Making Government Transparent and Accountable  - SunlightFoundation.com">Sunlight Foundation</a>.</p>
+  <p class="undo-indent">The following attributes were taken from the <a href="http://resource.org/8_principles.html" title="8 Principles of Open Government Data" target="_blank">8 principles</a> of open data developed in 2007 at the <a href="http://public.resource.org/open_government_meeting.html" title="Memorandum" target="_blank">Open Government Working Group</a> along with recent additional <a href="http://sunlightfoundation.com/policy/documents/ten-open-data-principles/" title="Policy Center - Ten Principles for Opening Up Government Information - SunlightFoundation.com" target="_blank">suggestions</a> by the <a href="http://sunlightfoundation.com/" title="Making Government Transparent and Accountable  - SunlightFoundation.com" target="_blank">Sunlight Foundation</a>.</p>
   <ul>
     <li><b>Complete</b><br />All public data is made available. Public data is data that is not subject to valid privacy, security or privilege limitations.</li>
     <li><b>Primary</b><br />Data is as collected at the source, with the highest possible level of granularity, not in aggregate or modified forms.</li>
@@ -37,9 +37,9 @@ layout: default
 
 
   <p>References:</p>
-  <p>[1] <a href="http://resource.org/8_principles.html" title="8 Principles of Open Government Data">8 Principles of Open Government Data</a>, resource.org</p>
-  <p>[2] <a href="http://sunlightfoundation.com/policy/documents/ten-open-data-principles/" title="Policy Center - Ten Principles for Opening Up Government Information - SunlightFoundation.com">Ten Principles for Opening Up Government Information</a>, Sunlight Foundation</p>
-  <p>[3] <a href="http://www.w3.org/DesignIssues/GovData" title="Putting Government Data online - Design Issues">Putting Government Data Online</a>, Sir Tim Berners-Lee</p>
+  <p>[1] <a href="http://resource.org/8_principles.html" title="8 Principles of Open Government Data" target="_blank">8 Principles of Open Government Data</a>, resource.org</p>
+  <p>[2] <a href="http://sunlightfoundation.com/policy/documents/ten-open-data-principles/" title="Policy Center - Ten Principles for Opening Up Government Information - SunlightFoundation.com" target="blank">Ten Principles for Opening Up Government Information</a>, Sunlight Foundation</p>
+  <p>[3] <a href="http://www.w3.org/DesignIssues/GovData" title="Putting Government Data online - Design Issues" target="_blank">Putting Government Data Online</a>, Sir Tim Berners-Lee</p>
 
 </div>
 

--- a/codeofconduct.md
+++ b/codeofconduct.md
@@ -25,7 +25,7 @@ OpenLexington reserves the right to ask anyone in violation of these policies no
 
 All OpenLexington network activities, events, and digital forums and their staff, presenters, and participants are held to an anti-harassment policy, included below.
 
-In addition to governing our own events by this policy, OpenLexington will only lend our brand and fund groups that offer an anti-harassment policy to their attendees. For information on how to offer an anti-harassment policy to your group, <a href="https://docs.google.com/a/codeforamerica.org/document/d/1Zg2FDt7awgfCmdcbzMwKHMb1A7KDOhs_z7ibCb3TLLQ/edit">see this guide</a>.
+In addition to governing our own events by this policy, OpenLexington will only lend our brand and fund groups that offer an anti-harassment policy to their attendees. For information on how to offer an anti-harassment policy to your group, <a href="https://docs.google.com/a/codeforamerica.org/document/d/1Zg2FDt7awgfCmdcbzMwKHMb1A7KDOhs_z7ibCb3TLLQ/edit" target="_blank">see this guide</a>.
 
 OpenLexington is dedicated to providing a harassment-free experience for everyone regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age, or religion. We do not tolerate harassment of staff, presenters, and participants in any form. Sexual language and imagery is not appropriate for any OpenLexington event or network activity, including talks. Anyone in violation of these policies may expelled from OpenLexington network activities, events, and digital forums, at the discretion of the event organizer or forum administrator.
 

--- a/getinvolved.html
+++ b/getinvolved.html
@@ -5,9 +5,9 @@ layout: default
 <h1 class="openlex-header">Get Involved with Open Lexington:</h1>
 <div class="getinvolved">
   <ul class="getinvolved">
-  <li id="getinvolved"><a href="https://groups.google.com/forum/#!forum/openlexington" class="project-title">Join the discussion on GoogleGroups</a></li>
-  <li><a href="https://twitter.com/openlexington/" class="project-title">Follow us on Twitter</a></li>
-  <li><a href="https://github.com/openlexington" class="project-title">Fork our code on GitHub</a></li>
-  <li><a href="http://meetup.com/OpenLexington" class="project-title">Attend a Hack Event</a></li>
+  <li id="getinvolved"><a href="https://groups.google.com/forum/#!forum/openlexington" class="project-title" target="_blank">Join the discussion on GoogleGroups</a></li>
+  <li><a href="https://twitter.com/openlexington/" class="project-title" target="_blank">Follow us on Twitter</a></li>
+  <li><a href="https://github.com/openlexington" class="project-title" target="_blank">Fork our code on GitHub</a></li>
+  <li><a href="http://meetup.com/OpenLexington" class="project-title" target="_blank">Attend a Hack Event</a></li>
   </ul>
 </div>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@ layout: default
   <div class="col-xs-12 col-sm-6 col-lg-6 text-center">
     <img src="img/current.png"><br>
     <a class="btn btn-large btn-info" href="http://www.openlexington.org/projects.html#current">Current Projects</a>
-    <p class="text-left main-description">We are working with the <a href="http://lexingtonky.gov">Lexington Fayette Urban County Government</a>, the <a href="http://www.uky.edu">University of Kentucky</a>, and <a href="http://codeforamerica.org">Code for America</a> to make local public data more open, available and useful.</p>
+    <p class="text-left main-description">We are working with the <a href="http://lexingtonky.gov" target="_blank">Lexington Fayette Urban County Government</a>, the <a href="http://www.uky.edu" target="_blank">University of Kentucky</a>, and <a href="http://codeforamerica.org" target="_blank">Code for America</a> to make local public data more open, available and useful.</p>
   </div>
 
   <div class="col-xs-12 col-sm-6 col-lg-6 text-center">
@@ -33,7 +33,7 @@ layout: default
     </div>
     <div class="col-xs-12 col-sm-6 col-lg-6">
       <p class="text-xs-center">
-        <a href="http://brigade.codeforamerica.org">
+        <a href="http://brigade.codeforamerica.org" target="_blank">
           <img class="solid" src="img/CfA_Brigade_logo_300.png" width="300" height="113" alt="Code for America Brigade" />
         </a>
       </p>

--- a/projects.html
+++ b/projects.html
@@ -5,25 +5,25 @@ layout: default
 <h1 class="openlex-header">OpenLexington Projects</h1>
 <div class="development" id="current">
   <h2 class="openlex-header">In Development:</h2>
-  <a href="https://github.com/openlexington/bus-alert" class="project-title">Bus Alert</a>
+  <a href="https://github.com/openlexington/bus-alert" class="project-title" target="_blank">Bus Alert</a>
   <span class="description">Lexington mobile app to alert you when your bus is approaching  </span>
-  <a href="https://github.com/openlexington/LIVES_viewer" class="project-title">LIVES Viewer</a>
+  <a href="https://github.com/openlexington/LIVES_viewer" class="project-title" target="_blank">LIVES Viewer</a>
   <span class="description">A simple web app for viewing LIVES standard health inspection data  </span>
-  <a href="https://github.com/openlexington/councilmatic" class="project-title">Councilmatic</a>
+  <a href="https://github.com/openlexington/councilmatic" class="project-title" target="_blank">Councilmatic</a>
   <span class="description">A City Council legislative information subscription service  </span>
-  <a href="https://github.com/openlexington/Lex_to_LIVES" class="project-title">Lex to LIVES</a>
+  <a href="https://github.com/openlexington/Lex_to_LIVES" class="project-title" target="_blank">Lex to LIVES</a>
   <span class="description">Lexington Health Dept. Health Inspection data to LIVES format  </span>
-  <a href="https://github.com/openlexington/WhatsMyDistrict" class="project-title">What's My District</a>
+  <a href="https://github.com/openlexington/WhatsMyDistrict" class="project-title" target="_blank">What's My District</a>
   <span class="description">According to your home address, an app that tells you your district and other zoning information  </span>
 </div>
 
 <div class="launched" id="past">
   <h2 class="openlex-header">Launched:</h2>
-  <a href="http://whatsmydistrict.org" class="project-title">What's My District</a>
+  <a href="http://whatsmydistrict.org" class="project-title" target="_blank">What's My District</a>
   <span class="description">According to your home address, an app that tells you your district and other zoning information  </span>
-  <a href="http://lexington-wiki.org" class="project-title">Local Wiki</a>
+  <a href="http://lexington-wiki.org" class="project-title" target="_blank">Local Wiki</a>
   <span class="description">A crowdsource of local knowledge about Lexington, KY  </span>
-  <a href="http://lookatlex.org" class="project-title">Look At Lexington</a>
+  <a href="http://lookatlex.org" class="project-title" target="_blank">Look At Lexington</a>
   <span class="description">A visualization of Lexington's 2013-2014 FY Budget</span>
   <a href="http://openlexington.github.io/lex_underutil/" class="project-title">Lex_Underutil</a>
   <span class="description">Tilemill map of underutilized properties in Lexington, Kentucky  </span>


### PR DESCRIPTION
Edits add `target="_blank"` to anchor elements linked to external URLs

- _includes/footer.html
- _includes/header.html
- about.html
- index.html
- codeofconduct.md
- getinvolved.html
- projects.html